### PR TITLE
[SP-173] Extend path handling to work with relative path not relative to cwd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+panopticapi.egg-info/
+**/__pycache__/

--- a/panopticapi/evaluation.py
+++ b/panopticapi/evaluation.py
@@ -84,12 +84,20 @@ def pq_compute_single_core(proc_id, annotation_set, gt_folder, pred_folder, cate
         idx += 1
 
         pan_gt_path = gt_ann['file_name']
+        # If 'file_name' contains only a file name without path segments
         if not os.path.split(pan_gt_path)[0]:
             pan_gt_path = os.path.join(gt_folder, pan_gt_path)
+        # If 'file_name' is a relative path pointing nowhere from cwd
+        elif not os.path.isabs(pan_gt_path) and not os.path.isfile(pan_gt_path):
+            pan_gt_path = os.path.join(gt_folder, os.path.basename(pan_gt_path))
 
         pan_pred_path = pred_ann['file_name']
+        # If 'file_name' contains only a file name without path segments
         if not os.path.split(pan_pred_path)[0]:
             pan_pred_path = os.path.join(pred_folder, pan_pred_path)
+        # If 'file_name' is a relative path pointing nowhere from cwd
+        elif not os.path.isabs(pan_pred_path) and not os.path.isfile(pan_pred_path):
+            pan_pred_path = os.path.join(gt_folder, os.path.basename(pan_pred_path))
 
         pan_gt = np.array(Image.open(pan_gt_path), dtype=np.uint32)
         pan_gt = rgb2id(pan_gt)


### PR DESCRIPTION
Added additional path handling for if 'file_name' is a relative path, but is not relative to cwd.

This is done so 'file_name' can be relative to file containing dataset info. Path is constructed using only basename of 'file_name' to prevent double mention of overlapping files in `gt_folder` and `pan_gt_folder`.

Example:
A dataset has the following structure:
```
DatasetFolder
├── Images
│   ├── image_00001.png
│   ├── image_00002.png
│   ├── image_00003.png
│   └── ...
├── Segmentation_Maps
│   ├── image_00001.png
│   ├── image_00002.png
│   ├── image_00003.png
│   └── ...
└── dataset.json
```
where `dataset.json` contains information about the dataset. It contains image and annotation fields with the 'file_name' keys. The keys are filled with relative path starting from dataset.json, e.g. `./Images/image_00001.png`.

In this case, `gt_folder` should be `DatasetFolder/Images`. If `os.path.join` would be applied to `gt_folder` and `file_name`, the result would be `DatasetFolder/Images/./Images/image_00001.png`. To prevent this, `gt_folder` is joined with the `basename` of `file_name`.