### PR TITLE
[SP-141] Revert allow paths in file name fields

### DIFF
--- a/panopticapi/evaluation.py
+++ b/panopticapi/evaluation.py
@@ -83,17 +83,9 @@ def pq_compute_single_core(proc_id, annotation_set, gt_folder, pred_folder, cate
             print('Core: {}, {} from {} images processed'.format(proc_id, idx, len(annotation_set)))
         idx += 1
 
-        pan_gt_path = gt_ann['file_name']
-        if not os.path.split(pan_gt_path)[0]:
-            pan_gt_path = os.path.join(gt_folder, pan_gt_path)
-
-        pan_pred_path = pred_ann['file_name']
-        if not os.path.split(pan_pred_path)[0]:
-            pan_pred_path = os.path.join(pred_folder, pan_pred_path)
-
-        pan_gt = np.array(Image.open(pan_gt_path), dtype=np.uint32)
+        pan_gt = np.array(Image.open(os.path.join(gt_folder, gt_ann['file_name'])), dtype=np.uint32)
         pan_gt = rgb2id(pan_gt)
-        pan_pred = np.array(Image.open(pan_pred_path), dtype=np.uint32)
+        pan_pred = np.array(Image.open(os.path.join(pred_folder, pred_ann['file_name'])), dtype=np.uint32)
         pan_pred = rgb2id(pan_pred)
 
         gt_segms = {el['id']: el for el in gt_ann['segments_info']}


### PR DESCRIPTION
Reverting previous changes as discussed in a [different PR](https://github.com/saia-agrobotics/EXTERNAL-panopticapi/pull/3#discussion_r1252000340). 

Changes should no longer be needed.

This reverts commit 1bef38ad64535e38557b189bbfc2ab4dd8c142c5, reversing changes made to eeca480c8e0ff10f9ab86df2b94a1cfaef37257c.